### PR TITLE
Fixed a little bug (Or at least I have it)

### DIFF
--- a/Lauhdutin/@Resources/Frontend/Settings.lua
+++ b/Lauhdutin/@Resources/Frontend/Settings.lua
@@ -130,7 +130,7 @@ function Exit()
 	if REBUILD_SWITCH then
 		SKIN:Bang('["#Python#" "#@#Frontend\\BuildSkin.py" "#PROGRAMPATH#;" "#@#;" "#CURRENTCONFIG#;" "#CURRENTFILE#;"]')
 	else
-		SKIN:Bang('[!ActivateConfig #CURRENTCONFIG# "Main.ini"]')
+		SKIN:Bang('[!ActivateConfig "#CURRENTCONFIG#" "Main.ini"]')
 	end	
 end
 

--- a/Lauhdutin/Settings.ini
+++ b/Lauhdutin/Settings.ini
@@ -10,7 +10,7 @@ Update=1000
 Blur=0
 ;DefaultUpdateDivider=-1
 ContextTitle="Switch to skin"
-ContextAction=[!ActivateConfig #CURRENTCONFIG# "Main.ini"]
+ContextAction=[!ActivateConfig "#CURRENTCONFIG#" "Main.ini"]
 
 [Variables]
 @Include=#@#PythonPath.inc


### PR DESCRIPTION
I want to know if It is a bug that I have or a general bug. In settings, when I press Exit (or with the entry on the context Menu) doesn't happens anything and in the debugger of Rainmeter appears "!ActivateConfig: invalid parameters". With this two little changes I solve it, but I don't know if it is a bug general or local.