### PR TITLE
Add play sound when a game is executed feature.

### DIFF
--- a/Lauhdutin/@Resources/Frontend/Enums.lua
+++ b/Lauhdutin/@Resources/Frontend/Enums.lua
@@ -4,6 +4,8 @@ return {
 		ANIMATION_CLICK = 'click_animation',
 		ANIMATION_HOVER = 'hover_animation',
 		ANIMATION_SKIN_SLIDE_DIRECTION = 'skin_slide_animation_direction',
+		SOUND_CLICK = 'sound_click',
+		SOUND_PATH = 'sound_path',
 		BANGS_STARTING = 'start_game_bang',
 		BANGS_STOPPING = 'stop_game_bang',
 		BATTLENET_PATH = 'battlenet_path',

--- a/Lauhdutin/@Resources/Frontend/GUI.lua
+++ b/Lauhdutin/@Resources/Frontend/GUI.lua
@@ -330,6 +330,9 @@
 				C_ANIMATIONS:PushHoverReset(anIndex)
 			end
 			if N_ACTION_STATE == E_ACTION_STATES.EXECUTE then
+				if T_SETTINGS[E_SETTING_KEYS.SOUND_CLICK] == true then
+				SKIN:Bang('[Play "' .. T_SETTINGS[E_SETTING_KEYS.SOUND_PATH] .. '"]')
+				end
 				C_ANIMATIONS:PushClick(nAnimation, anIndex, LaunchGame, tGame)
 			elseif N_ACTION_STATE == E_ACTION_STATES.HIDE then
 				C_ANIMATIONS:PushClick(nAnimation, anIndex, HideGame, tGame)
@@ -338,6 +341,9 @@
 			end
 		else
 			if N_ACTION_STATE == E_ACTION_STATES.EXECUTE then
+				if T_SETTINGS[E_SETTING_KEYS.SOUND_CLICK] == true then
+				SKIN:Bang('[Play "' .. T_SETTINGS[E_SETTING_KEYS.SOUND_PATH] .. '"]')
+				end
 				LaunchGame(tGame)
 			elseif N_ACTION_STATE == E_ACTION_STATES.HIDE then
 				HideGame(tGame)

--- a/Lauhdutin/@Resources/Frontend/Settings.lua
+++ b/Lauhdutin/@Resources/Frontend/Settings.lua
@@ -100,6 +100,12 @@ function Initialize()
 		"Jiggle",
 		"Shake"
 	}
+	if SETTINGS[SETTING_KEYS.SOUND_CLICK] == nil then
+		SETTINGS[SETTING_KEYS.SOUND_CLICK] = false
+	end
+	if SETTINGS[SETTING_KEYS.SOUND_PATH] == nil then
+		SETTINGS[SETTING_KEYS.SOUND_PATH] = ""
+	end
 	if SETTINGS[SETTING_KEYS.FUZZY_SEARCH] == nil then
 		SETTINGS[SETTING_KEYS.FUZZY_SEARCH] = true
 	end
@@ -273,6 +279,8 @@ function UpdateSettings()
 		SKIN:Bang('[!SetOption "BattlenetPathInput" "DefaultValue" "' .. SETTINGS[SETTING_KEYS.BATTLENET_PATH] ..'"]')
 		SKIN:Bang('[!SetOption "PythonPathStatus" "Text" "' .. tostring(SETTINGS[SETTING_KEYS.PYTHON_PATH]) .. '"]')
 		SKIN:Bang('[!SetOption "PythonPathInput" "DefaultValue" "' .. SETTINGS[SETTING_KEYS.PYTHON_PATH] ..'"]')
+		SKIN:Bang('[!SetOption "SoundPathStatus" "Text" "' .. tostring(SETTINGS[SETTING_KEYS.SOUND_PATH]) .. '"]')
+		SKIN:Bang('[!SetOption "SoundPathInput" "DefaultValue" "' .. SETTINGS[SETTING_KEYS.SOUND_PATH] ..'"]')
 		if SETTINGS[SETTING_KEYS.ORIENTATION] == 'vertical' then
 			SKIN:Bang('[!SetOption "SkinOrientationStatus" "Text" "Vertical"]')
 		else
@@ -307,6 +315,11 @@ function UpdateSettings()
 			SKIN:Bang('[!SetOption "HoverAnimationStatus" "Text" "Disabled"]')
 		else
 			SKIN:Bang('[!SetOption "HoverAnimationStatus" "Text" "' .. HOVER_ANIMATION_DESCRIPTIONS[SETTINGS[SETTING_KEYS.ANIMATION_HOVER]] .. '"]')
+		end
+		if SETTINGS[SETTING_KEYS.SOUND_CLICK] == true then
+			SKIN:Bang('[!SetOption "PlaySoundClickStatus" "Text" "Enabled"]')
+		else
+			SKIN:Bang('[!SetOption "PlaySoundClickStatus" "Text" "Disabled"]')
 		end
 		if SETTINGS[SETTING_KEYS.FUZZY_SEARCH] == true then
 			SKIN:Bang('[!SetOption "FuzzySearchStatus" "Text" "Enabled"]')
@@ -626,6 +639,20 @@ function CycleHoverAnimation()
 	if SETTINGS[SETTING_KEYS.ANIMATION_HOVER] > #HOVER_ANIMATION_DESCRIPTIONS then
 		SETTINGS[SETTING_KEYS.ANIMATION_HOVER] = 0
 	end
+	UpdateSettings()
+end
+
+function TogglePlaySoundClick()
+	SETTINGS[SETTING_KEYS.SOUND_CLICK] = not SETTINGS[SETTING_KEYS.SOUND_CLICK]
+	UpdateSettings()
+end
+
+function RequestSoundPath()
+	SKIN:Bang('"#Python#" "#@#Frontend\\GenericFilePathDialog.py" "#PROGRAMPATH#;" "AcceptSoundPath;" "' .. SETTINGS[SETTING_KEYS.SOUND_PATH] .. '"; "#CURRENTCONFIG#;"')
+end
+
+function AcceptSoundPath(aPath)
+	SETTINGS[SETTING_KEYS.SOUND_PATH] = aPath
 	UpdateSettings()
 end
 

--- a/Lauhdutin/Settings.ini
+++ b/Lauhdutin/Settings.ini
@@ -15,7 +15,7 @@ ContextAction=[!ActivateConfig "#CURRENTCONFIG#" "Main.ini"]
 [Variables]
 @Include=#@#PythonPath.inc
 WindowWidth=900
-WindowHeight=780
+WindowHeight=830
 TabHeight=50
 WindowColor=64,64,64,255
 TextFieldColor=48,48,48,255
@@ -785,6 +785,44 @@ AntiAlias=1
 DynamicVariables=1
 Group=Layout
 
+;------------------------ Play sound on click ------------------------
+[PlaySoundClickTitle]
+Meter=String
+MeterStyle=LayoutOptionTitleTemplate
+X=(#WindowWidth# / 2 + #IncrementButtonDimension# / 2)
+Y=(2 * #TabHeight# + 10 + (#IncrementButtonDimension# / 2))
+Text=Sound on click
+ToolTipTitle=Sound on click
+ToolTipText=This setting determines if a sound have to be played when a game is executed or not. Requires a sound path to be defined.
+
+[PlaySoundClickButton]
+Meter=Image
+X=(#WindowWidth# / 4)r
+Y=(-#IncrementButtonDimension# / 2)r
+W=(#WindowWidth# / 8 + 5 * #IncrementButtonDimension# / 2)
+H=#IncrementButtonDimension#
+SolidColor=#ButtonColor#
+DynamicVariables=1
+LeftMouseDownAction=[!CommandMeasure "SettingsScript" "TogglePlaySoundClick()"]
+Group=Layout
+
+[PlaySoundClickStatus]
+Meter=String
+X=(3 * #IncrementButtonDimension#)r
+Y=(#IncrementButtonDimension# / 2)r
+W=((#WindowWidth# / 2) - 1)
+H=#IncrementButtonDimension#
+Text=Disabled
+FontFace=Arial
+FontSize=(#TabHeight#/3)
+FontColor=#ButtonTextColor#
+StringAlign=CenterCenter
+StringEffect=Shadow
+ClipString=1
+AntiAlias=1
+DynamicVariables=1
+Group=Layout
+
 ;======================== Path settings ========================
 ;------------------------ Steam path ------------------------
 [SteamPathTitle]
@@ -1343,6 +1381,51 @@ StringAlign=CenterCenter
 StringEffect=Shadow
 ClipString=1
 AntiAlias=1
+DynamicVariables=1
+Group=Paths
+
+;------------------------ Sound path ------------------------
+[SoundPathTitle]
+Meter=String
+MeterStyle=PathOptionTitleTemplate
+Y=(14 * #TabHeight# + 10 + (#IncrementButtonDimension# / 2))
+Text=Sound path
+ToolTipTitle=Sound path
+ToolTipText=The file path to the file that you want to play when a game is executed. E.g. 'C:\Music\Sound.mp3'. Requires sound on click to be enabled.
+
+[SoundPathTextField]
+Meter=Image
+MeterStyle=PathTextFieldTemplate
+
+[SoundPathStatus]
+Meter=String
+MeterStyle=PathStatusTemplate
+Text=
+LeftMouseUpAction=[!CommandMeasure "SoundPathInput" "ExecuteBatch 1"]
+
+[SoundPathBrowseButton]
+Meter=Image
+MeterStyle=PathBrowseButtonTemplate
+LeftMouseDownAction=[!CommandMeasure "SettingsScript" "RequestSoundPath()"]
+
+[SoundPathBrowseTitle]
+Meter=String
+MeterStyle=PathBrowseTitleTemplate
+
+[SoundPathInput]
+Measure=Plugin
+Plugin=InputText
+SolidColor=#TextFieldColor#
+FontColor=255,255,255,255
+FontFace=Arial
+StringAlign=Right
+FontSize=(#TabHeight#/3)
+X=(3 / 2 * #IncrementButtonDimension# + #WindowWidth# / 4 + 30)
+Y=(1 * #TabHeight# + 10)
+W=(#WindowWidth# / 2)
+H=#IncrementButtonDimension#
+DefaultValue=
+Command1=[!CommandMeasure "SettingsScript" "AcceptSoundPath('$UserInput$')"]
 DynamicVariables=1
 Group=Paths
 

--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,7 @@ A Rainmeter skin for aggregating games from different platforms and then launchi
    - [Manual process override](#manual-process-override)
    - [Highlighting](#highlighting)
    - [Animations](#animations)
+   - [Sound](#sound)
  - [Reporting issues](#reporting-issues)
  - [Contributing](#contributing)
  - [Changelog](#changelog)
@@ -238,6 +239,10 @@ Hover animations can be disabled completely.
 The entire skin can be made to slide into and out of view when placed along an edge of a monitor ([animated example](Docs/SkinAnimation.gif)). There is a setting that can be used to determine which direction the skin slides into and out of view. A 1 px wide/tall invisible sliver is placed along the corresponding edge of the skin when this feature is enabled and hovering the mouse cursor on this sliver makes the skin slide into view.
 
 Skin animations can be disabled completely.
+
+## Sound
+
+If sound on click is enabled and a sound file path is defined, a sound will be played when a game is executed.
 
 # Reporting issues
 If you encounter an issue while trying to use Lauhdutin, then please read through the readme in case there is an explanation on how to deal with the issue.

--- a/Readme.md
+++ b/Readme.md
@@ -242,7 +242,7 @@ Skin animations can be disabled completely.
 
 ## Sound
 
-If sound on click is enabled and a sound file path is defined, a sound will be played when a game is executed.
+If sound on click is enabled and a sound file path is defined, that sound will be played when a game is executed.
 
 # Reporting issues
 If you encounter an issue while trying to use Lauhdutin, then please read through the readme in case there is an explanation on how to deal with the issue.


### PR DESCRIPTION
With this feature, if the feature is enabled and a sound is defined, that sound will be played when a game is executed. This could be helpful to confirm that you click the slot (especially if the double click feature is enabled).

I add in the Appareance tab the setting to enable or disabled this, and in the Functionalitity tab the setting to define the path.

I test it and I think it is fully working now, except for the error I have on #97 that are present here too. 

EDIT: When fixed #97 I don't see any error on that setting either, so I think everything is working as expected.