### PR TITLE
Show uninstalled and hidden fixed (fixes #103)

### DIFF
--- a/Lauhdutin/@Resources/Frontend/GUI.lua
+++ b/Lauhdutin/@Resources/Frontend/GUI.lua
@@ -1517,16 +1517,7 @@
 		if STRING:StartsWith(asPattern, '+') then
 			T_FILTERED_GAMES, bSort = Filter(T_FILTERED_GAMES, asPattern:sub(2))
 		else
-			local tTableOfGames = {}
-			for i, tGame in ipairs(T_ALL_GAMES) do
-				if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
-				   or (tGame[E_GAME_KEYS.NOT_INSTALLED]
-				   	  and T_SETTINGS[E_SETTING_KEYS.SHOW_NOT_INSTALLED_GAMES])
-				   or (not tGame[E_GAME_KEYS.HIDDEN] and not tGame[E_GAME_KEYS.NOT_INSTALLED]) then
-					table.insert(tTableOfGames, tGame)
-				end
-			end
-			T_FILTERED_GAMES, bSort = Filter(tTableOfGames, asPattern)
+			T_FILTERED_GAMES, bSort = Filter(T_ALL_GAMES, asPattern)
 		end
 		if bSort then
 			SortGames()
@@ -1542,43 +1533,64 @@
 		if STRING:StartsWith(asPattern, 'i') then --platform:installed
 			for i, tGame in ipairs(atTable) do
 				if tGame[E_GAME_KEYS.PLATFORM] == anPlatform and tGame[E_GAME_KEYS.NOT_INSTALLED] ~= true then
-					table.insert(tResult, tGame)
+					if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    or not tGame[E_GAME_KEYS.HIDDEN] then
+						table.insert(tResult, tGame)
+					end
 				end
 			end
 		elseif STRING:StartsWith(asPattern, 'u') then --platform:uninstalled
 			for i, tGame in ipairs(atTable) do
 				if tGame[E_GAME_KEYS.PLATFORM] == anPlatform and tGame[E_GAME_KEYS.NOT_INSTALLED] == true then
-					table.insert(tResult, tGame)
+					if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    or not tGame[E_GAME_KEYS.HIDDEN] then
+						table.insert(tResult, tGame)
+					end
 				end
 			end
 		elseif STRING:StartsWith(asPattern, 'a') then --platform:all
 			for i, tGame in ipairs(atTable) do
 				if tGame[E_GAME_KEYS.PLATFORM] == anPlatform then
-					table.insert(tResult, tGame)
+					if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    or not tGame[E_GAME_KEYS.HIDDEN] then
+						table.insert(tResult, tGame)
+					end
 				end
 			end
 		elseif STRING:StartsWith(asPattern, 'p') then --platform:played
 			for i, tGame in ipairs(atTable) do
 				if tGame[E_GAME_KEYS.PLATFORM] == anPlatform and tGame[E_GAME_KEYS.HOURS_TOTAL] > 0 then
-					table.insert(tResult, tGame)
+					if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    or not tGame[E_GAME_KEYS.HIDDEN] then
+						table.insert(tResult, tGame)
+					end
 				end
 			end
 		elseif STRING:StartsWith(asPattern, 'n') then --platform:not played
 			for i, tGame in ipairs(atTable) do
 				if tGame[E_GAME_KEYS.PLATFORM] == anPlatform and tGame[E_GAME_KEYS.HOURS_TOTAL] <= 0 then
-					table.insert(tResult, tGame)
+					if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    or not tGame[E_GAME_KEYS.HIDDEN] then
+						table.insert(tResult, tGame)
+					end
 				end
 			end
 		elseif STRING:StartsWith(asPattern, 't') then --platform:true
 			for i, tGame in ipairs(atTable) do
 				if tGame[E_GAME_KEYS.PLATFORM] == anPlatform then
-					table.insert(tResult, tGame)
+					if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    or not tGame[E_GAME_KEYS.HIDDEN] then
+						table.insert(tResult, tGame)
+					end
 				end
 			end
 		elseif STRING:StartsWith(asPattern, 'f') then --platform:false
 			for i, tGame in ipairs(atTable) do
 				if tGame[E_GAME_KEYS.PLATFORM] ~= anPlatform then
-					table.insert(tResult, tGame)
+					if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    or not tGame[E_GAME_KEYS.HIDDEN] then
+						table.insert(tResult, tGame)
+					end
 				end
 			end
 		end
@@ -1615,13 +1627,19 @@
 			if STRING:StartsWith(asPattern, 't') then
 				for i, tGame in ipairs(T_ALL_GAMES) do
 					if tGame[E_GAME_KEYS.NOT_INSTALLED] ~= true then
-						table.insert(tResult, tGame)
+						if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    	    or not tGame[E_GAME_KEYS.HIDDEN] then
+							table.insert(tResult, tGame)
+						end
 					end
 				end				
 			elseif STRING:StartsWith(asPattern, 'f') then
 				for i, tGame in ipairs(T_ALL_GAMES) do
 					if tGame[E_GAME_KEYS.NOT_INSTALLED] == true then
-						table.insert(tResult, tGame)
+						if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    	    or not tGame[E_GAME_KEYS.HIDDEN] then
+							table.insert(tResult, tGame)
+						end
 					end
 				end
 			end
@@ -1728,13 +1746,19 @@
 			if STRING:StartsWith(asPattern, 't') then
 				for i, tGame in ipairs(atTable) do
 					if tGame[E_GAME_KEYS.HOURS_TOTAL] > 0 then
-						table.insert(tResult, tGame)
+						if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    	    or not tGame[E_GAME_KEYS.HIDDEN] then
+							table.insert(tResult, tGame)
+						end
 					end
 				end
 			elseif STRING:StartsWith(asPattern, 'f') then	
 				for i, tGame in ipairs(atTable) do
 					if tGame[E_GAME_KEYS.HOURS_TOTAL] <= 0 then
-						table.insert(tResult, tGame)
+						if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    	    or not tGame[E_GAME_KEYS.HIDDEN] then
+							table.insert(tResult, tGame)
+						end
 					end
 				end
 			end
@@ -1744,7 +1768,10 @@
 				for i, tGame in ipairs(atTable) do
 					if tGame[E_GAME_KEYS.PLATFORM] == E_PLATFORMS.WINDOWS_SHORTCUT
 					   or tGame[E_GAME_KEYS.PLATFORM] == E_PLATFORMS.WINDOWS_URL_SHORTCUT then
-						table.insert(tResult, tGame)
+						if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    	    or not tGame[E_GAME_KEYS.HIDDEN] then
+							table.insert(tResult, tGame)
+						end
 					end
 				end
 			else
@@ -1753,7 +1780,10 @@
 					   or tGame[E_GAME_KEYS.PLATFORM] == E_PLATFORMS.WINDOWS_URL_SHORTCUT then
 						if tGame[E_GAME_KEYS.PLATFORM_OVERRIDE] ~= nil
 						   and tGame[E_GAME_KEYS.PLATFORM_OVERRIDE]:lower():find(asPattern) then
-							table.insert(tResult, tGame)
+							if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    	    	    or not tGame[E_GAME_KEYS.HIDDEN] then
+								table.insert(tResult, tGame)
+							end
 						end
 					end
 				end

--- a/Lauhdutin/@Resources/Frontend/GUI.lua
+++ b/Lauhdutin/@Resources/Frontend/GUI.lua
@@ -1801,14 +1801,26 @@
 				--print("== " .. asPattern .. " ==") -- Debug
 				for i, entry in ipairs(tRankings) do
 					--print(entry.score, entry.game[E_GAME_KEYS.NAME]) -- Debug
-					table.insert(tResult, entry.game)
+					if (entry.game[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					    or not entry.game[E_GAME_KEYS.HIDDEN] then
+						if (entry.game[E_GAME_KEYS.NOT_INSTALLED] and T_SETTINGS[E_SETTING_KEYS.SHOW_NOT_INSTALLED_GAMES])
+					    	    or not entry.game[E_GAME_KEYS.NOT_INSTALLED] then
+							table.insert(tResult, entry.game)
+						end
+					end
 				end
 				C_TOOLBAR:SetScoreSortingIcon()
 				return tResult, false
 			else
 				for i, tGame in ipairs(atTable) do
 					if tGame[E_GAME_KEYS.NAME]:lower():find(asPattern) then
-						table.insert(tResult, tGame)
+						if (tGame[E_GAME_KEYS.HIDDEN] and T_SETTINGS[E_SETTING_KEYS.SHOW_HIDDEN_GAMES])
+					   	    or not tGame[E_GAME_KEYS.HIDDEN] then
+							if (tGame[E_GAME_KEYS.NOT_INSTALLED] and T_SETTINGS[E_SETTING_KEYS.SHOW_NOT_INSTALLED_GAMES])
+					    	    	    or not tGame[E_GAME_KEYS.NOT_INSTALLED] then
+								table.insert(tResult, tGame)
+							end
+						end
 					end
 				end
 			end


### PR DESCRIPTION
This was the issue before (from #103 ):

> If you have a game that is uninstalled and hidden, even disabling show hidden games that game are showing on the filtering of uninstalled games. For example, I have ABZU on Steam uninstalled and hidden. I enable show uninstalled games, but disable show hidden games. So, teorically, ABZU shouldn't be showed when I use Steam:uninstalled filter, but it is showed.
> 
> If you disable show uninstalled games, if you use for example steam:uninstalled, it says "No matches", even having uninstalled games that are unhidden.

With this PR should be fixed now.