### PR TITLE
Fixed a little issue with spanish translation

### DIFF
--- a/dist/@Resources/game/init.lua
+++ b/dist/@Resources/game/init.lua
@@ -420,7 +420,7 @@ createProperties = function(game, platform)
     if process ~= nil and process ~= '' then
       return process
     end
-    return LOCALIZATION:get('button_label_none', 'None')
+    return LOCALIZATION:get('button_label_none_process', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('game_process', 'Process'),
@@ -440,7 +440,7 @@ createProperties = function(game, platform)
       end
       return line
     end
-    return LOCALIZATION:get('button_label_none', 'None')
+    return LOCALIZATION:get('button_label_none_notes', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('game_notes', 'Notes'),
@@ -476,7 +476,7 @@ createProperties = function(game, platform)
         return str
       end
     end
-    return LOCALIZATION:get('button_label_none', 'None')
+    return LOCALIZATION:get('button_label_none_tags', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('game_tags', 'Tags'),
@@ -530,7 +530,7 @@ createProperties = function(game, platform)
         return (bangs:gsub('\"', '\'\''))
       end
     end
-    return LOCALIZATION:get('button_label_none', 'None')
+    return LOCALIZATION:get('button_label_none_bangs', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('button_label_starting_bangs', 'Starting bangs'),
@@ -548,7 +548,7 @@ createProperties = function(game, platform)
         return (bangs:gsub('\"', '\'\''))
       end
     end
-    return LOCALIZATION:get('button_label_none', 'None')
+    return LOCALIZATION:get('button_label_none_bangs', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('button_label_stopping_bangs', 'Stopping bangs'),

--- a/dist/@Resources/game/init.lua
+++ b/dist/@Resources/game/init.lua
@@ -420,7 +420,7 @@ createProperties = function(game, platform)
     if process ~= nil and process ~= '' then
       return process
     end
-    return LOCALIZATION:get('button_label_none_process', 'None')
+    return LOCALIZATION:get('game_process_none', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('game_process', 'Process'),
@@ -440,7 +440,7 @@ createProperties = function(game, platform)
       end
       return line
     end
-    return LOCALIZATION:get('button_label_none_notes', 'None')
+    return LOCALIZATION:get('game_notes_none', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('game_notes', 'Notes'),
@@ -476,7 +476,7 @@ createProperties = function(game, platform)
         return str
       end
     end
-    return LOCALIZATION:get('button_label_none_tags', 'None')
+    return LOCALIZATION:get('game_tags_none', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('game_tags', 'Tags'),
@@ -530,7 +530,7 @@ createProperties = function(game, platform)
         return (bangs:gsub('\"', '\'\''))
       end
     end
-    return LOCALIZATION:get('button_label_none_bangs', 'None')
+    return LOCALIZATION:get('button_label_bangs_none', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('button_label_starting_bangs', 'Starting bangs'),
@@ -548,7 +548,7 @@ createProperties = function(game, platform)
         return (bangs:gsub('\"', '\'\''))
       end
     end
-    return LOCALIZATION:get('button_label_none_bangs', 'None')
+    return LOCALIZATION:get('button_label_bangs_none', 'None')
   end
   table.insert(properties, Property({
     title = LOCALIZATION:get('button_label_stopping_bangs', 'Stopping bangs'),

--- a/dist/@Resources/settings/pages/skin.lua
+++ b/dist/@Resources/settings/pages/skin.lua
@@ -67,7 +67,7 @@ getLanguageIndex = function()
 end
 state.slotHoverAnimations = {
   {
-    displayValue = LOCALIZATION:get('button_label_none', 'None')
+    displayValue = LOCALIZATION:get('button_label_none_animation', 'None')
   },
   {
     displayValue = LOCALIZATION:get('setting_animation_label_zoom_in', 'Zoom in')
@@ -84,7 +84,7 @@ state.slotHoverAnimations = {
 }
 state.slotClickAnimations = {
   {
-    displayValue = LOCALIZATION:get('button_label_none', 'None')
+    displayValue = LOCALIZATION:get('button_label_none_animation', 'None')
   },
   {
     displayValue = LOCALIZATION:get('setting_animation_label_slide_up', 'Slide upwards')
@@ -104,7 +104,7 @@ state.slotClickAnimations = {
 }
 state.skinAnimations = {
   {
-    displayValue = LOCALIZATION:get('button_label_none', 'None')
+    displayValue = LOCALIZATION:get('button_label_none_animation', 'None')
   },
   {
     displayValue = LOCALIZATION:get('setting_animation_label_slide_up', 'Slide upwards')

--- a/dist/@Resources/settings/pages/skin.lua
+++ b/dist/@Resources/settings/pages/skin.lua
@@ -67,7 +67,7 @@ getLanguageIndex = function()
 end
 state.slotHoverAnimations = {
   {
-    displayValue = LOCALIZATION:get('button_label_none_animation', 'None')
+    displayValue = LOCALIZATION:get('setting_animation_label_none', 'None')
   },
   {
     displayValue = LOCALIZATION:get('setting_animation_label_zoom_in', 'Zoom in')
@@ -84,7 +84,7 @@ state.slotHoverAnimations = {
 }
 state.slotClickAnimations = {
   {
-    displayValue = LOCALIZATION:get('button_label_none_animation', 'None')
+    displayValue = LOCALIZATION:get('setting_animation_label_none', 'None')
   },
   {
     displayValue = LOCALIZATION:get('setting_animation_label_slide_up', 'Slide upwards')
@@ -104,7 +104,7 @@ state.slotClickAnimations = {
 }
 state.skinAnimations = {
   {
-    displayValue = LOCALIZATION:get('button_label_none_animation', 'None')
+    displayValue = LOCALIZATION:get('setting_animation_label_none', 'None')
   },
   {
     displayValue = LOCALIZATION:get('setting_animation_label_slide_up', 'Slide upwards')

--- a/src/game/init.moon
+++ b/src/game/init.moon
@@ -315,7 +315,7 @@ createProperties = (game, platform) ->
 		process = game\getProcess(true)
 		if process ~= nil and process ~= ''
 			return process 
-		return LOCALIZATION\get('button_label_none_process', 'None')
+		return LOCALIZATION\get('game_process_none', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('game_process', 'Process')
@@ -333,7 +333,7 @@ createProperties = (game, platform) ->
 			line = lines[1]
 			line ..= '...' if #lines > 1
 			return line
-		return LOCALIZATION\get('button_label_none_notes', 'None')
+		return LOCALIZATION\get('game_notes_none', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('game_notes', 'Notes')
@@ -360,7 +360,7 @@ createProperties = (game, platform) ->
 			str = str\sub(4)
 			if str ~= ''
 				return str
-		return LOCALIZATION\get('button_label_none_tags', 'None')
+		return LOCALIZATION\get('game_tags_none', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('game_tags', 'Tags')
@@ -401,7 +401,7 @@ createProperties = (game, platform) ->
 			bangs = table.concat(bangs, ' | ')
 			if bangs ~= ''
 				return (bangs\gsub('\"', '\'\''))
-		return LOCALIZATION\get('button_label_none_bangs', 'None')
+		return LOCALIZATION\get('button_label_bangs_none', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('button_label_starting_bangs', 'Starting bangs')
@@ -418,7 +418,7 @@ createProperties = (game, platform) ->
 			bangs = table.concat(bangs, ' | ')
 			if bangs ~= ''
 				return (bangs\gsub('\"', '\'\''))
-		return LOCALIZATION\get('button_label_none_bangs', 'None')
+		return LOCALIZATION\get('button_label_bangs_none', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('button_label_stopping_bangs', 'Stopping bangs')

--- a/src/game/init.moon
+++ b/src/game/init.moon
@@ -315,7 +315,7 @@ createProperties = (game, platform) ->
 		process = game\getProcess(true)
 		if process ~= nil and process ~= ''
 			return process 
-		return LOCALIZATION\get('button_label_none', 'None')
+		return LOCALIZATION\get('button_label_none_process', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('game_process', 'Process')
@@ -333,7 +333,7 @@ createProperties = (game, platform) ->
 			line = lines[1]
 			line ..= '...' if #lines > 1
 			return line
-		return LOCALIZATION\get('button_label_none', 'None')
+		return LOCALIZATION\get('button_label_none_notes', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('game_notes', 'Notes')
@@ -360,7 +360,7 @@ createProperties = (game, platform) ->
 			str = str\sub(4)
 			if str ~= ''
 				return str
-		return LOCALIZATION\get('button_label_none', 'None')
+		return LOCALIZATION\get('button_label_none_tags', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('game_tags', 'Tags')
@@ -401,7 +401,7 @@ createProperties = (game, platform) ->
 			bangs = table.concat(bangs, ' | ')
 			if bangs ~= ''
 				return (bangs\gsub('\"', '\'\''))
-		return LOCALIZATION\get('button_label_none', 'None')
+		return LOCALIZATION\get('button_label_none_bangs', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('button_label_starting_bangs', 'Starting bangs')
@@ -418,7 +418,7 @@ createProperties = (game, platform) ->
 			bangs = table.concat(bangs, ' | ')
 			if bangs ~= ''
 				return (bangs\gsub('\"', '\'\''))
-		return LOCALIZATION\get('button_label_none', 'None')
+		return LOCALIZATION\get('button_label_none_bangs', 'None')
 	table.insert(properties,
 		Property({
 			title: LOCALIZATION\get('button_label_stopping_bangs', 'Stopping bangs')

--- a/src/settings/pages/skin.moon
+++ b/src/settings/pages/skin.moon
@@ -44,7 +44,7 @@ getLanguageIndex = () ->
 
 -- Slot hover animations
 state.slotHoverAnimations = {
-	{displayValue: LOCALIZATION\get('button_label_none', 'None')}
+	{displayValue: LOCALIZATION\get('button_label_none_animation', 'None')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_zoom_in', 'Zoom in')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_jiggle', 'Jiggle')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_shake_left_right', 'Shake left and right')}
@@ -52,7 +52,7 @@ state.slotHoverAnimations = {
 }
 -- Slot click animations
 state.slotClickAnimations = {
-	{displayValue: LOCALIZATION\get('button_label_none', 'None')}
+	{displayValue: LOCALIZATION\get('button_label_none_animation', 'None')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_up', 'Slide upwards')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_right', 'Slide to the right')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_down', 'Slide downwards')}
@@ -61,7 +61,7 @@ state.slotClickAnimations = {
 }
 -- Skin animations
 state.skinAnimations = {
-	{displayValue: LOCALIZATION\get('button_label_none', 'None')}
+	{displayValue: LOCALIZATION\get('button_label_none_animation', 'None')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_up', 'Slide upwards')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_right', 'Slide to the right')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_down', 'Slide downwards')}

--- a/src/settings/pages/skin.moon
+++ b/src/settings/pages/skin.moon
@@ -44,7 +44,7 @@ getLanguageIndex = () ->
 
 -- Slot hover animations
 state.slotHoverAnimations = {
-	{displayValue: LOCALIZATION\get('button_label_none_animation', 'None')}
+	{displayValue: LOCALIZATION\get('setting_animation_label_none', 'None')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_zoom_in', 'Zoom in')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_jiggle', 'Jiggle')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_shake_left_right', 'Shake left and right')}
@@ -52,7 +52,7 @@ state.slotHoverAnimations = {
 }
 -- Slot click animations
 state.slotClickAnimations = {
-	{displayValue: LOCALIZATION\get('button_label_none_animation', 'None')}
+	{displayValue: LOCALIZATION\get('setting_animation_label_none', 'None')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_up', 'Slide upwards')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_right', 'Slide to the right')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_down', 'Slide downwards')}
@@ -61,7 +61,7 @@ state.slotClickAnimations = {
 }
 -- Skin animations
 state.skinAnimations = {
-	{displayValue: LOCALIZATION\get('button_label_none_animation', 'None')}
+	{displayValue: LOCALIZATION\get('setting_animation_label_none', 'None')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_up', 'Slide upwards')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_right', 'Slide to the right')}
 	{displayValue: LOCALIZATION\get('setting_animation_label_slide_down', 'Slide downwards')}

--- a/translations/English.txt
+++ b/translations/English.txt
@@ -8,15 +8,11 @@ button_label_edit	Edit
 button_label_enabled	Enabled
 button_label_hours_played	Hours played
 button_label_no	No
-button_label_none_animation	None
-button_label_none_process	None
-button_label_none_notes	None
-button_label_none_tags	None
-button_label_none_bangs	None
 button_label_open	Open
 button_label_save	Save
 button_label_starting_bangs	Starting bangs
 button_label_stopping_bangs	Stopping bangs
+button_label_bangs_none	None
 button_label_yes	Yes
 filter_back_button_title	Back
 filter_clear_filters	Clear filters
@@ -36,12 +32,15 @@ game_last_played	Last played
 game_last_played_never	Never
 game_no_banner	No banner
 game_notes	Notes
+game_notes_none	None
 game_number_of_games	%d games
 game_path	Path
 game_platform	Platform
 game_process	Process
+game_process_none	None
 game_tag_create	Create a new tag
 game_tags	Tags
+game_tags_none	None
 game_visible	Visible
 main_context_title_execute_stopping_bangs	Execute stopping bangs
 main_context_title_open_shortcuts_folder	Open shortcuts folder
@@ -77,6 +76,7 @@ setting_animation_label_slide_left	Slide to the left
 setting_animation_label_slide_right	Slide to the right
 setting_animation_label_slide_up	Slide upwards
 setting_animation_label_zoom_in	Zoom in
+setting_animation_label_none	None
 setting_bangs_enabled_description	If enabled, then the specified Rainmeter bangs are executed when a game starts or terminates.
 setting_bangs_enabled_title	Execute bangs
 setting_bangs_starting_description	These Rainmeter bangs are executed just before any game launches.

--- a/translations/English.txt
+++ b/translations/English.txt
@@ -8,7 +8,11 @@ button_label_edit	Edit
 button_label_enabled	Enabled
 button_label_hours_played	Hours played
 button_label_no	No
-button_label_none	None
+button_label_none_animation	None
+button_label_none_process	None
+button_label_none_notes	None
+button_label_none_tags	None
+button_label_none_bangs	None
 button_label_open	Open
 button_label_save	Save
 button_label_starting_bangs	Starting bangs


### PR DESCRIPTION
Hello again! I encontered a little issue when translating the skin. In spanish, "none" could be translated as "ninguno" or "ninguna" regarding the genre of the word (For example, in animation settings would be translated as "Ninguna", and in "process" would be translated as "Ninguno"). I made two different ways of solve this issue:

- In solution 1, ([Language1 branch on my repository](https://github.com/BanCrash/Lauhdutin/tree/Language1)) I changed "button_label_none" to "button_label_none_masc" (masculine) and "button_label_none_fem" (femenine). This solution solve the issue in Spanish and only adds one more line on translation file. However, could make troubles with other languages.

- In solution 2 (this PR), I created "button_label_none_animation", "button_label_none_process", "button_label_none_notes", "button_label_none_tags" and "button_label_none_bangs". This solution probably would work for much languages, however added 4 more lines that are unnecesary on English language.

About solution 2, I renamed the strings as suffixes to have all "nones" together. However, if you think it's better to keep consistency I could rename them to their proper name and placed on their right place (for example "setting_animation_label_none").