### PR TITLE
Replace unsupported steam profile characters

### DIFF
--- a/dist/@Resources/settings/pages/steam.lua
+++ b/dist/@Resources/settings/pages/steam.lua
@@ -29,7 +29,7 @@ getPersonaName = function(accountID)
   if config.friends == nil then
     return nil
   end
-  return config.friends.personaname
+  return utility.replaceUnsupportedChars(config.friends.personaname)
 end
 local updateUsers
 updateUsers = function()
@@ -49,7 +49,7 @@ updateUsers = function()
           break
         end
         for communityID, user in pairs(users) do
-          if user.personaname == personaName then
+          if utility.replaceUnsupportedChars(user.personaname) == personaName then
             table.insert(state.accounts, {
               accountID = accountID,
               communityID = communityID,

--- a/src/settings/pages/steam.moon
+++ b/src/settings/pages/steam.moon
@@ -19,7 +19,7 @@ getPersonaName = (accountID) ->
 	config = vdf.userlocalconfigstore if config == nil
 	return nil if config == nil
 	return nil if config.friends == nil
-	return config.friends.personaname
+	return utility.replaceUnsupportedChars(config.friends.personaname)
 
 updateUsers = () -> 
 	state.accounts = {}
@@ -32,7 +32,7 @@ updateUsers = () ->
 			personaName = getPersonaName(accountID)
 			continue if personaName == nil
 			for communityID, user in pairs(users)
-				if user.personaname == personaName
+				if utility.replaceUnsupportedChars(user.personaname) == personaName
 					table.insert(state.accounts, {
 						:accountID
 						:communityID 


### PR DESCRIPTION
With this little fix, if Steam profile name has unsupported characters, will be replaced using the utility.

By the way, testing this matter I found that if you change your profile name, PersonaName in "loginusers.vdf" aren't update, causing that you can't set that profile until you restart Steam (because user.personaname will be different than personaName). No much can be done in this matter I think, just noting it for if can be useful in future issues.