### PR TITLE
Updated GOG Galaxy platform

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+**Version 3.0.2 - 2018/05/30:**
+- Updated to support the latest version of GOG Galaxy.
+
 **Version 3.0.1 - 2018/05/26:**
 - Fixed the manner in which arguments of Windows shortcuts are parsed.
 

--- a/dist/@Resources/main/platforms/gog_galaxy/dumpDatabases.bat
+++ b/dist/@Resources/main/platforms/gog_galaxy/dumpDatabases.bat
@@ -13,7 +13,14 @@ set "galaxy="%cd%\galaxy.txt""
 if exist %galaxy% del %galaxy%
 cd ..\..\
 set "sqlite="%cd%\sqlite3.exe""
-start /B "" %sqlite% %1 "select productId, localpath from Products;" > %index%
+:: index.db has been removed and the data has been moved into galaxy.db.
+:: This is just to support the scenarios where the client has not been
+:: updated and where the client has been updated.
+if exist %1 (
+	start /B "" %sqlite% %1 "select productId, localpath from Products;" > %index%
+) else (
+	start /B "" %sqlite% %2 "select productId, installationPath from InstalledBaseProducts;" > %index%
+)
 start /B "" %sqlite% %2 "select productId, title, images from LimitedDetails;" > %galaxy%
 echo "" > %completed%
 ::pause

--- a/dist/@Resources/main/platforms/gog_galaxy/init.lua
+++ b/dist/@Resources/main/platforms/gog_galaxy/init.lua
@@ -7,8 +7,7 @@ do
   local _parent_0 = Platform
   local _base_0 = {
     validate = function(self)
-      assert(io.fileExists(io.joinPaths(self.programDataPath, 'storage\\index.db'), false), 'The path to GOG Galaxy\'s ProgramData directory is not valid.')
-      assert(io.fileExists(io.joinPaths(self.programDataPath, 'storage\\index.db'), false), 'The path to GOG Galaxy\'s ProgramData directory is not valid.')
+      assert(io.fileExists(io.joinPaths(self.programDataPath, 'storage\\galaxy.db'), false), 'The path to GOG Galaxy\'s ProgramData directory is not valid.')
       if self.clientPath ~= nil then
         self.clientPath = io.joinPaths(self.clientPath, 'GalaxyClient.exe')
         if self.indirectLaunch then
@@ -28,7 +27,6 @@ do
       assert(self.programDataPath ~= nil, 'The path to GOG Galaxy\'s ProgramData path has not been defined.')
       local indexDBPath = io.joinPaths(self.programDataPath, 'storage\\index.db')
       local galaxyDBPath = io.joinPaths(self.programDataPath, 'storage\\galaxy.db')
-      assert(io.fileExists(indexDBPath, false) == true, ('"%s" does not exist.'):format(indexDBPath))
       assert(io.fileExists(galaxyDBPath, false) == true, ('"%s" does not exist.'):format(galaxyDBPath))
       local sqlitePath = io.joinPaths(STATE.PATHS.RESOURCES, 'sqlite3.exe')
       assert(io.fileExists(sqlitePath, false) == true, ('SQLite3 CLI tool is missing. Expected the path to be "%s".'):format(sqlitePath))

--- a/dist/Main.ini
+++ b/dist/Main.ini
@@ -2,7 +2,7 @@
 Name=Lauhdutin
 Author=Kapiainen
 Information=A game launcher with support for various digital distribution platforms.
-Version=3.0.1
+Version=3.0.2
 License=MIT
 
 [Rainmeter]

--- a/src/main/platforms/gog_galaxy/init.moon
+++ b/src/main/platforms/gog_galaxy/init.moon
@@ -2,9 +2,14 @@ Platform = require('main.platforms.platform')
 Game = require('main.game')
 json = require('lib.json')
 
--- Dump "productId" and "localpath" columns from the "Products" table of "index.db":
--- - productId: Unique ID associated with a game.
--- - localpath: The absolute path to the folder containing the game.
+-- New version
+--   Dump "productId" and "installationPath" columns from the "InstalledBaseProducts" table of "galaxy.db":
+--   - productId: Unique ID associated with a game.
+--   - installationPath: The absolute path to the folder containing the game.
+-- Old version
+--   Dump "productId" and "localpath" columns from the "Products" table of "index.db":
+--   - productId: Unique ID associated with a game.
+--   - localpath: The absolute path to the folder containing the game.
 --
 -- Dump "productId", "title", and "images" columns from the "LimitedDetails" table of "galaxy.db"
 -- - productId: Same as above.
@@ -31,8 +36,7 @@ class GOGGalaxy extends Platform
 		@games = {}
 
 	validate: () =>
-		assert(io.fileExists(io.joinPaths(@programDataPath, 'storage\\index.db'), false), 'The path to GOG Galaxy\'s ProgramData directory is not valid.')
-		assert(io.fileExists(io.joinPaths(@programDataPath, 'storage\\index.db'), false), 'The path to GOG Galaxy\'s ProgramData directory is not valid.')
+		assert(io.fileExists(io.joinPaths(@programDataPath, 'storage\\galaxy.db'), false), 'The path to GOG Galaxy\'s ProgramData directory is not valid.')
 		if @clientPath ~= nil
 			@clientPath = io.joinPaths(@clientPath, 'GalaxyClient.exe')
 			if @indirectLaunch
@@ -48,7 +52,6 @@ class GOGGalaxy extends Platform
 		assert(@programDataPath ~= nil, 'The path to GOG Galaxy\'s ProgramData path has not been defined.')
 		indexDBPath = io.joinPaths(@programDataPath, 'storage\\index.db')
 		galaxyDBPath = io.joinPaths(@programDataPath, 'storage\\galaxy.db')
-		assert(io.fileExists(indexDBPath, false) == true, ('"%s" does not exist.')\format(indexDBPath))
 		assert(io.fileExists(galaxyDBPath, false) == true, ('"%s" does not exist.')\format(galaxyDBPath))
 		sqlitePath = io.joinPaths(STATE.PATHS.RESOURCES, 'sqlite3.exe')
 		assert(io.fileExists(sqlitePath, false) == true, ('SQLite3 CLI tool is missing. Expected the path to be "%s".')\format(sqlitePath))


### PR DESCRIPTION
The contents of "index.db" have been moved into "galaxy.db" and
"index.db" has been removed in a recent GOG Galaxy update. The skin
currently supports the old and new versions of GOG Galaxy.