### PR TITLE
 Added ability to search uninstalled and hidden games

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Added the ability to redownload a game's banner via the Game menu. Only available for Steam and GOG Galaxy games.
 - Added the ability to open a game's store page in the system's default browser. Only available for Steam and GOG Galaxy games.
 - Added the ability to invert filters (i.e. `Has notes` becomes `Does not have notes`).
+- Added the ability to search on uninstalled and / or hidden games besides installed games when left-clicking search button.
 - Added an optional Session skin that shows the current system time and the current gaming session's duration in HH:MM format while playing a game. Can be enabled/disabled via a setting.
 - Added a new `Custom` platform and settings for it.
 - Added a new `Add a game` custom skin action, which can be used to add a game (`Custom` platform) by inputting information into a new menu.

--- a/Readme.md
+++ b/Readme.md
@@ -160,7 +160,7 @@ The toolbar, which can be made visible by hovering the mouse over the top or bot
 
 The button on the left-hand side of the toolbar is for searching for games based on the title. Searching uses fuzzy matching, which means that you do not need to input the exact same title as the game you are looking for. Titles are instead compared to the input and given a score. Using just the initials of a game's title should be enough to place it at the top of the list of results in many cases (e.g. `wtno` for `Wolfenstein: The New Order`).
 
-- Left-clicking the button searches through all installed games.
+- Left-clicking the button searches through all installed games, besides uninstalled and / or hidden games if pertinent settings are enabled.
 - Middle-clicking the button searches through the current list of games, which might be the result of applying various filters.
 - Right-clicking the button clears all filters and resets the list of games. It can also be used to instantly go to the beginning of the list of games.
 

--- a/dist/@Resources/settings/pages/skin.lua
+++ b/dist/@Resources/settings/pages/skin.lua
@@ -441,6 +441,28 @@ do
             return utility.runCommand(('""%s""'):format(io.joinPaths(STATE.PATHS.RESOURCES, path)), '', 'OnEditedGlobalStoppingBangs')
           end
         }),
+        Settings.Boolean({
+          title = LOCALIZATION:get('setting_search_uninstalled_games_enabled_title', 'Uninstalled games on search'),
+          tooltip = LOCALIZATION:get('setting_search_uninstalled_games_enabled_description', 'If enabled, then uninstalled games will be showed when searching with left-click action.'),
+          toggle = function()
+            COMPONENTS.SETTINGS:toggleSearchUninstalledGamesEnabled()
+            return true
+          end,
+          getState = function()
+            return COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
+          end
+        }),
+        Settings.Boolean({
+          title = LOCALIZATION:get('setting_search_hidden_games_enabled_title', 'Hidden games on search'),
+          tooltip = LOCALIZATION:get('setting_search_hidden_games_enabled_description', 'If enabled, then hidden games will be showed when searching with left-click action.'),
+          toggle = function()
+            COMPONENTS.SETTINGS:toggleSearchHiddenGamesEnabled()
+            return true
+          end,
+          getState = function()
+            return COMPONENTS.SETTINGS:getSearchHiddenGamesEnabled()
+          end
+        }),
         Settings.Spinner({
           title = LOCALIZATION:get('setting_localization_language_title', 'Language'),
           tooltip = LOCALIZATION:get('setting_localization_language_description', 'Select a language.'),

--- a/dist/@Resources/shared/library.lua
+++ b/dist/@Resources/shared/library.lua
@@ -397,8 +397,8 @@ do
         })
       else
         gamesToProcess = { }
-        local uninstalledGamesEnabled = COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
-        local hiddenGamesEnabled = COMPONENTS.SETTINGS:getSearchHiddenGamesEnabled()
+        local searchUninstalledGames = COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
+        local searchHiddenGames = COMPONENTS.SETTINGS:getSearchHiddenGamesEnabled()
         local _list_0 = self.games
         for _index_0 = 1, #_list_0 do
           local _continue_0 = false
@@ -409,18 +409,18 @@ do
               break
             end
             if not game:isVisible() then
-              if not game:isInstalled() and hiddenGamesEnabled == true then
-                if not (uninstalledGamesEnabled == true) then
+              if not game:isInstalled() and searchHiddenGames == true then
+                if not (searchUninstalledGames == true) then
                   _continue_0 = true
                   break
                 end
               end
-              if not (filter == ENUMS.FILTER_TYPES.HIDDEN or filter == ENUMS.FILTER_TYPES.TITLE and hiddenGamesEnabled == true) then
+              if not (filter == ENUMS.FILTER_TYPES.HIDDEN or filter == ENUMS.FILTER_TYPES.TITLE and searchHiddenGames == true) then
                 _continue_0 = true
                 break
               end
             elseif not game:isInstalled() then
-              if not (filter == ENUMS.FILTER_TYPES.UNINSTALLED or filter == ENUMS.FILTER_TYPES.TITLE and uninstalledGamesEnabled == true) then
+              if not (filter == ENUMS.FILTER_TYPES.UNINSTALLED or filter == ENUMS.FILTER_TYPES.TITLE and searchUninstalledGames == true) then
                 _continue_0 = true
                 break
               end

--- a/dist/@Resources/shared/library.lua
+++ b/dist/@Resources/shared/library.lua
@@ -407,12 +407,21 @@ do
               break
             end
             if not game:isVisible() then
-              if not (filter == ENUMS.FILTER_TYPES.HIDDEN) then
+              local hiddenGamesEnabled = COMPONENTS.SETTINGS:getSearchHiddenGamesEnabled()
+              if not game:isInstalled() and hiddenGamesEnabled == true then
+                local uninstalledGamesEnabled = COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
+                if not (uninstalledGamesEnabled == true) then
+                  _continue_0 = true
+                  break
+                end
+              end
+              if not (filter == ENUMS.FILTER_TYPES.HIDDEN or filter == ENUMS.FILTER_TYPES.TITLE and hiddenGamesEnabled == true) then
                 _continue_0 = true
                 break
               end
             elseif not game:isInstalled() then
-              if not (filter == ENUMS.FILTER_TYPES.UNINSTALLED) then
+              local uninstalledGamesEnabled = COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
+              if not (filter == ENUMS.FILTER_TYPES.UNINSTALLED or filter == ENUMS.FILTER_TYPES.TITLE and uninstalledGamesEnabled == true) then
                 _continue_0 = true
                 break
               end

--- a/dist/@Resources/shared/library.lua
+++ b/dist/@Resources/shared/library.lua
@@ -397,6 +397,8 @@ do
         })
       else
         gamesToProcess = { }
+        local uninstalledGamesEnabled = COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
+        local hiddenGamesEnabled = COMPONENTS.SETTINGS:getSearchHiddenGamesEnabled()
         local _list_0 = self.games
         for _index_0 = 1, #_list_0 do
           local _continue_0 = false
@@ -407,9 +409,7 @@ do
               break
             end
             if not game:isVisible() then
-              local hiddenGamesEnabled = COMPONENTS.SETTINGS:getSearchHiddenGamesEnabled()
               if not game:isInstalled() and hiddenGamesEnabled == true then
-                local uninstalledGamesEnabled = COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
                 if not (uninstalledGamesEnabled == true) then
                   _continue_0 = true
                   break
@@ -420,7 +420,6 @@ do
                 break
               end
             elseif not game:isInstalled() then
-              local uninstalledGamesEnabled = COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
               if not (filter == ENUMS.FILTER_TYPES.UNINSTALLED or filter == ENUMS.FILTER_TYPES.TITLE and uninstalledGamesEnabled == true) then
                 _continue_0 = true
                 break

--- a/dist/@Resources/shared/settings.lua
+++ b/dist/@Resources/shared/settings.lua
@@ -162,6 +162,9 @@ local migrators = {
       settings.slots.overlayLowerText = ENUMS.OVERLAY_SLOT_TEXT.TIME_PLAYED_HOURS_OR_MINUTES
       settings.slots.overlayImagesEnabled = true
       settings.showSession = false
+      settings.search = { }
+      settings.search.uninstalledGamesEnabled = false
+      settings.search.hiddenGamesEnabled = false
       settings.platforms.custom = { }
       settings.platforms.custom.bangs = {
         starting = { },
@@ -337,6 +340,18 @@ do
         end
       end
       self.settings.bangs.global.stopping = bangs
+    end,
+    getSearchUninstalledGamesEnabled = function(self)
+      return self.settings.search.uninstalledGamesEnabled or false
+    end,
+    toggleSearchUninstalledGamesEnabled = function(self)
+      self.settings.search.uninstalledGamesEnabled = not self.settings.search.uninstalledGamesEnabled
+    end,
+    getSearchHiddenGamesEnabled = function(self)
+      return self.settings.search.hiddenGamesEnabled or false
+    end,
+    toggleSearchHiddenGamesEnabled = function(self)
+      self.settings.search.hiddenGamesEnabled = not self.settings.search.hiddenGamesEnabled
     end,
     getLayoutRows = function(self)
       return self.settings.layout.rows or 1
@@ -757,6 +772,10 @@ do
             starting = { },
             stopping = { }
           }
+        },
+        search = {
+          uninstalledGamesEnabled = false,
+          hiddenGamesEnabled = false
         },
         layout = {
           rows = 1,

--- a/src/settings/pages/skin.moon
+++ b/src/settings/pages/skin.moon
@@ -329,6 +329,24 @@ class Skin extends Page
 					io.writeFile(path, table.concat(bangs, '\n'))
 					utility.runCommand(('""%s""')\format(io.joinPaths(STATE.PATHS.RESOURCES, path)), '', 'OnEditedGlobalStoppingBangs')
 			})
+			Settings.Boolean({
+				title: LOCALIZATION\get('setting_search_uninstalled_games_enabled_title', 'Uninstalled games on search')
+				tooltip: LOCALIZATION\get('setting_search_uninstalled_games_enabled_description', 'If enabled, then uninstalled games will be showed when searching with left-click action.')
+				toggle: () ->
+					COMPONENTS.SETTINGS\toggleSearchUninstalledGamesEnabled()
+					return true
+				getState: () ->
+					return COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
+			})
+			Settings.Boolean({
+				title: LOCALIZATION\get('setting_search_hidden_games_enabled_title', 'Hidden games on search')
+				tooltip: LOCALIZATION\get('setting_search_hidden_games_enabled_description', 'If enabled, then hidden games will be showed when searching with left-click action.')
+				toggle: () ->
+					COMPONENTS.SETTINGS\toggleSearchHiddenGamesEnabled()
+					return true
+				getState: () ->
+					return COMPONENTS.SETTINGS\getSearchHiddenGamesEnabled()
+			})
 			Settings.Spinner({
 				title: LOCALIZATION\get('setting_localization_language_title', 'Language')
 				tooltip: LOCALIZATION\get('setting_localization_language_description', 'Select a language.')

--- a/src/shared/library.moon
+++ b/src/shared/library.moon
@@ -332,16 +332,16 @@ class Library
 			})
 		else
 			gamesToProcess = {}
-			uninstalledGamesEnabled = COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
-			hiddenGamesEnabled = COMPONENTS.SETTINGS\getSearchHiddenGamesEnabled()
+			searchUninstalledGames = COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
+			searchHiddenGames = COMPONENTS.SETTINGS\getSearchHiddenGamesEnabled()
 			for game in *@games
 				continue unless @platformEnabledStatus[game\getPlatformID()] == true
 				if not game\isVisible()
-					if not game\isInstalled() and hiddenGamesEnabled == true
-						continue unless uninstalledGamesEnabled == true
-					continue unless filter == ENUMS.FILTER_TYPES.HIDDEN or filter == ENUMS.FILTER_TYPES.TITLE and hiddenGamesEnabled == true
+					if not game\isInstalled() and searchHiddenGames == true
+						continue unless searchUninstalledGames == true
+					continue unless filter == ENUMS.FILTER_TYPES.HIDDEN or filter == ENUMS.FILTER_TYPES.TITLE and searchHiddenGames == true
 				elseif not game\isInstalled()
-					continue unless filter == ENUMS.FILTER_TYPES.UNINSTALLED or filter == ENUMS.FILTER_TYPES.TITLE and uninstalledGamesEnabled == true
+					continue unless filter == ENUMS.FILTER_TYPES.UNINSTALLED or filter == ENUMS.FILTER_TYPES.TITLE and searchUninstalledGames == true
 				table.insert(gamesToProcess, game)
 			if filter == ENUMS.FILTER_TYPES.NONE
 				@filterStack = {}

--- a/src/shared/library.moon
+++ b/src/shared/library.moon
@@ -335,9 +335,14 @@ class Library
 			for game in *@games
 				continue unless @platformEnabledStatus[game\getPlatformID()] == true
 				if not game\isVisible()
-					continue unless filter == ENUMS.FILTER_TYPES.HIDDEN
+					hiddenGamesEnabled = COMPONENTS.SETTINGS\getSearchHiddenGamesEnabled()
+					if not game\isInstalled() and hiddenGamesEnabled == true
+						uninstalledGamesEnabled = COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
+						continue unless uninstalledGamesEnabled == true
+					continue unless filter == ENUMS.FILTER_TYPES.HIDDEN or filter == ENUMS.FILTER_TYPES.TITLE and hiddenGamesEnabled == true
 				elseif not game\isInstalled()
-					continue unless filter == ENUMS.FILTER_TYPES.UNINSTALLED
+					uninstalledGamesEnabled = COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
+					continue unless filter == ENUMS.FILTER_TYPES.UNINSTALLED or filter == ENUMS.FILTER_TYPES.TITLE and uninstalledGamesEnabled == true
 				table.insert(gamesToProcess, game)
 			if filter == ENUMS.FILTER_TYPES.NONE
 				@filterStack = {}

--- a/src/shared/library.moon
+++ b/src/shared/library.moon
@@ -332,16 +332,15 @@ class Library
 			})
 		else
 			gamesToProcess = {}
+			uninstalledGamesEnabled = COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
+			hiddenGamesEnabled = COMPONENTS.SETTINGS\getSearchHiddenGamesEnabled()
 			for game in *@games
 				continue unless @platformEnabledStatus[game\getPlatformID()] == true
 				if not game\isVisible()
-					hiddenGamesEnabled = COMPONENTS.SETTINGS\getSearchHiddenGamesEnabled()
 					if not game\isInstalled() and hiddenGamesEnabled == true
-						uninstalledGamesEnabled = COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
 						continue unless uninstalledGamesEnabled == true
 					continue unless filter == ENUMS.FILTER_TYPES.HIDDEN or filter == ENUMS.FILTER_TYPES.TITLE and hiddenGamesEnabled == true
 				elseif not game\isInstalled()
-					uninstalledGamesEnabled = COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
 					continue unless filter == ENUMS.FILTER_TYPES.UNINSTALLED or filter == ENUMS.FILTER_TYPES.TITLE and uninstalledGamesEnabled == true
 				table.insert(gamesToProcess, game)
 			if filter == ENUMS.FILTER_TYPES.NONE

--- a/src/shared/settings.moon
+++ b/src/shared/settings.moon
@@ -145,6 +145,9 @@ migrators = {
 			settings.slots.overlayLowerText = ENUMS.OVERLAY_SLOT_TEXT.TIME_PLAYED_HOURS_OR_MINUTES
 			settings.slots.overlayImagesEnabled = true
 			settings.showSession = false
+			settings.search = {}
+			settings.search.uninstalledGamesEnabled = false
+			settings.search.hiddenGamesEnabled = false
 			settings.platforms.custom = {}
 			settings.platforms.custom.bangs = {
 				starting: {}
@@ -169,6 +172,10 @@ class Settings
 					starting: {} -- Bangs that are executed by ALL games when a game is launched.
 					stopping: {} -- Bangs that are executed by ALL games when a game terminates.
 				}
+			}
+			search: {
+				uninstalledGamesEnabled: false
+				hiddenGamesEnabled: false
 			}
 			layout: {
 				rows: 1 -- The number of rows of slots.
@@ -345,6 +352,15 @@ class Settings
 			bang = bang\trim()
 			table.insert(bangs, bang) if bang ~= ''
 		@settings.bangs.global.stopping = bangs
+
+	-- Search
+	getSearchUninstalledGamesEnabled: () => return @settings.search.uninstalledGamesEnabled or false
+
+	toggleSearchUninstalledGamesEnabled: () => @settings.search.uninstalledGamesEnabled = not @settings.search.uninstalledGamesEnabled
+
+	getSearchHiddenGamesEnabled: () => return @settings.search.hiddenGamesEnabled or false
+
+	toggleSearchHiddenGamesEnabled: () => @settings.search.hiddenGamesEnabled = not @settings.search.hiddenGamesEnabled
 
 	-- Layout
 	getLayoutRows: () => return @settings.layout.rows or 1

--- a/translations/English.txt
+++ b/translations/English.txt
@@ -140,6 +140,10 @@ setting_logging_description	If enabled, then a bunch of messages are printed to 
 setting_logging_title	Log
 setting_number_of_backups_description	The number of daily backups to keep of the list of games.
 setting_number_of_backups_title	Number of backups
+setting_search_hidden_games_enabled_description If enabled, then hidden games will be showed when searching with left-click action.
+setting_search_hidden_games_enabled_title Hidden games on search
+setting_search_uninstalled_games_enabled_description  If enabled, then uninstalled games will be showed when searching with left-click action.
+setting_search_uninstalled_games_enabled_title  Uninstalled games on search
 setting_shortcuts_enabled_description	If enabled, then Windows shortcuts placed in the designated folder will be included.
 setting_shortcuts_open_folder_description	Shortcuts and their banners should be placed in this folder. The banners should be named after their corresponding shortcut.
 setting_shortcuts_open_folder_title	Folder


### PR DESCRIPTION
Hello! I added the ability of searching on hidden and / or uninstalled games that were on 2.x version. I added the pertinent settings and by default are disabled. I made the changes to moon files and then I compiled them.

To use this is necessary to use a 3.0.x settings file or delete previous 3.1 settings file, because a new table is added to version 2 migrators, but if settings are already on version 2 will not be added, causing the skin to fail to launch. 

I tried to keep consistency with the code. I also complicated a little bit hidden filtering to avoid the scenario where a game is hidden and uninstalled, and show hidden games is enabled but show uninstalled games is disabled, so without that modification will show that game even if it's uninstalled.

I tested it with every scenario that come to mind and don't found any issue.

Feel free to reject this, ask for any changes or any explanation regarding my modifications.
