### PR TITLE
Fixed a bug when COMPONENTS doesn't exist

### DIFF
--- a/dist/@Resources/shared/library.lua
+++ b/dist/@Resources/shared/library.lua
@@ -397,8 +397,12 @@ do
         })
       else
         gamesToProcess = { }
-        local searchUninstalledGames = COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
-        local searchHiddenGames = COMPONENTS.SETTINGS:getSearchHiddenGamesEnabled()
+        local searchUninstalledGames = false
+        local searchHiddenGames = false
+        if COMPONENTS ~= nil then
+          searchUninstalledGames = COMPONENTS.SETTINGS:getSearchUninstalledGamesEnabled()
+          searchHiddenGames = COMPONENTS.SETTINGS:getSearchHiddenGamesEnabled()
+        end
         local _list_0 = self.games
         for _index_0 = 1, #_list_0 do
           local _continue_0 = false

--- a/src/shared/library.moon
+++ b/src/shared/library.moon
@@ -332,8 +332,11 @@ class Library
 			})
 		else
 			gamesToProcess = {}
-			searchUninstalledGames = COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
-			searchHiddenGames = COMPONENTS.SETTINGS\getSearchHiddenGamesEnabled()
+			searchUninstalledGames = false
+			searchHiddenGames = false
+			if COMPONENTS ~= nil then
+				searchUninstalledGames = COMPONENTS.SETTINGS\getSearchUninstalledGamesEnabled()
+				searchHiddenGames = COMPONENTS.SETTINGS\getSearchHiddenGamesEnabled()
 			for game in *@games
 				continue unless @platformEnabledStatus[game\getPlatformID()] == true
 				if not game\isVisible()


### PR DESCRIPTION
Regarding my previous PR I found an issue when COMPONENTS variable isn't initialized, so now will check if COMPONENTS exists, and if not will assign "false" value to the previous added variables.

This issue happened when middle-click on filter icon. This commit doesn't change the functioning of the search function.