### PR TITLE
Added banners for battle.net except Starcraft I & II

### DIFF
--- a/dist/@Resources/main/platforms/battlenet/init.lua
+++ b/dist/@Resources/main/platforms/battlenet/init.lua
@@ -50,7 +50,8 @@ do
             args = {
               title = 'Destiny 2',
               path = 'battlenet://DST2',
-              process = 'destiny2.exe'
+              process = 'destiny2.exe',
+              bannerURL = 'https://images.launchbox-app.com/34b4f780-34a2-42f0-a4ea-fa78933dd5e8.jpg'
             }
           elseif 'diablo iii' == _exp_0 then
             args = {
@@ -62,13 +63,15 @@ do
                 else
                   return 'Diablo III.exe'
                 end
-              end)()
+              end)(),
+              bannerURL = 'https://images.launchbox-app.com/9c1d2d30-8845-4b8a-89e6-632abab530c5.png'
             }
           elseif 'hearthstone' == _exp_0 then
             args = {
               title = 'Hearthstone',
               path = 'battlenet://WTCG',
-              process = 'Hearthstone.exe'
+              process = 'Hearthstone.exe',
+              bannerURL = 'https://images.launchbox-app.com/5aa3fd48-4edd-4d8a-a302-9eed46f3e471.png'
             }
           elseif 'heroes of the storm' == _exp_0 then
             args = {
@@ -80,13 +83,15 @@ do
                 else
                   return 'HeroesOfTheStorm.exe'
                 end
-              end)()
+              end)(),
+              bannerURL = 'https://images.launchbox-app.com/cb0aba61-915e-40e3-b2e1-187158819711.jpg'
             }
           elseif 'overwatch' == _exp_0 then
             args = {
               title = 'Overwatch',
               path = 'battlenet://Pro',
-              process = 'Overwatch.exe'
+              process = 'Overwatch.exe',
+              bannerURL = 'https://images.launchbox-app.com/09b1d6e3-316d-44d8-beca-90b87eb18c35.jpg'
             }
           elseif 'starcraft' == _exp_0 then
             args = {
@@ -116,7 +121,8 @@ do
                 else
                   return 'Wow.exe'
                 end
-              end)()
+              end)(),
+              bannerURL = 'https://images.launchbox-app.com/09a032b5-b86e-435a-b75a-264fcaa8a05d.png'
             }
           else
             _continue_0 = true

--- a/src/main/platforms/battlenet/init.moon
+++ b/src/main/platforms/battlenet/init.moon
@@ -50,35 +50,35 @@ class Battlenet extends Platform
 						title: 'Destiny 2'
 						path: 'battlenet://DST2'
 						process: 'destiny2.exe' -- No 32-bit executable
-						--bannerURL: ''
+						bannerURL: 'https://images.launchbox-app.com/34b4f780-34a2-42f0-a4ea-fa78933dd5e8.jpg'
 					}
 				when 'diablo iii'
 					args = {
 						title: 'Diablo III'
 						path: 'battlenet://D3'
 						process: if bits == 64 then 'Diablo III64.exe' else 'Diablo III.exe'
-						--bannerURL: ''
+						bannerURL: 'https://images.launchbox-app.com/9c1d2d30-8845-4b8a-89e6-632abab530c5.png'
 					}
 				when 'hearthstone'
 					args = {
 						title: 'Hearthstone'
 						path: 'battlenet://WTCG'
 						process: 'Hearthstone.exe' -- No 64-bit executable
-						--bannerURL: ''
+						bannerURL: 'https://images.launchbox-app.com/5aa3fd48-4edd-4d8a-a302-9eed46f3e471.png'
 					}
 				when 'heroes of the storm'
 					args = {
 						title: 'Heroes of the Storm'
 						path: 'battlenet://Hero'
 						process: if bits == 64 then 'HeroesOfTheStorm_x64.exe' else 'HeroesOfTheStorm.exe'
-						--bannerURL: ''
+						bannerURL: 'https://images.launchbox-app.com/cb0aba61-915e-40e3-b2e1-187158819711.jpg'
 					}
 				when 'overwatch'
 					args = {
 						title: 'Overwatch'
 						path: 'battlenet://Pro'
 						process: 'Overwatch.exe' -- No 32-bit executable
-						--bannerURL: ''
+						bannerURL: 'https://images.launchbox-app.com/09b1d6e3-316d-44d8-beca-90b87eb18c35.jpg'
 					}
 				when 'starcraft'
 					args = {
@@ -99,7 +99,7 @@ class Battlenet extends Platform
 						title: 'World of Warcraft'
 						path: 'battlenet://WoW'
 						process: if bits == 64 then 'Wow-64.exe' else 'Wow.exe'
-						--bannerURL: ''
+						bannerURL: 'https://images.launchbox-app.com/09a032b5-b86e-435a-b75a-264fcaa8a05d.png'
 					}
 				else
 					continue


### PR DESCRIPTION
Hello! I check [Launchbox Games database](https://gamesdb.launchbox-app.com/) and found images that can be used as banners for battle.net. I failed to get from that or another web banners for Starcraft I and II, but at least only remains those 2 and not all.

There are banners that are bigger and other smallers, but I downloaded all of them within Rainmeter and in my opinion do their job properly. I let here the links so you can check them easily if you want:

> https://images.launchbox-app.com/09b1d6e3-316d-44d8-beca-90b87eb18c35.jpg
https://images.launchbox-app.com/34b4f780-34a2-42f0-a4ea-fa78933dd5e8.jpg
https://images.launchbox-app.com/09a032b5-b86e-435a-b75a-264fcaa8a05d.png
https://images.launchbox-app.com/cb0aba61-915e-40e3-b2e1-187158819711.jpg
https://images.launchbox-app.com/9c1d2d30-8845-4b8a-89e6-632abab530c5.png
https://images.launchbox-app.com/5aa3fd48-4edd-4d8a-a302-9eed46f3e471.png

EDIT: This is how they look with default slot banner size: (don't know if Github compress photograps)

![image](https://user-images.githubusercontent.com/11770760/41061802-22b73a46-69d4-11e8-9a1c-dda907a183b6.png)

