### PR TITLE
Fixed a little issue with path spaces

### DIFF
--- a/dist/@Resources/settings/pages/shortcuts.lua
+++ b/dist/@Resources/settings/pages/shortcuts.lua
@@ -29,7 +29,7 @@ do
           tooltip = LOCALIZATION:get('setting_shortcuts_open_folder_description', 'Shortcuts and their banners should be placed in this folder. The banners should be named after their corresponding shortcut.'),
           label = LOCALIZATION:get('button_label_open', 'Open'),
           perform = function(self)
-            return SKIN:Bang(('[%s]'):format(io.joinPaths(STATE.PATHS.RESOURCES, 'Shortcuts\\')))
+            return SKIN:Bang(('["%s"]'):format(io.joinPaths(STATE.PATHS.RESOURCES, 'Shortcuts\\')))
           end
         }),
         Settings.Action({

--- a/dist/@Resources/shared/utility.lua
+++ b/dist/@Resources/shared/utility.lua
@@ -513,7 +513,7 @@ return {
     assert(type(parameter) == 'string', 'shared.utility.runCommand')
     assert(type(output) == 'string', 'shared.utility.runCommand')
     assert(type(callback) == 'string', 'shared.utility.runCommand')
-    SKIN:Bang(('[!SetOption "Command" "Parameter" "%s"]'):format(parameter))
+    SKIN:Bang('[!SetOption "Command" "Parameter" """' .. parameter .. '"""]')
     SKIN:Bang(('[!SetOption "Command" "OutputFile" "%s"]'):format(output))
     SKIN:Bang(('[!SetOption "Command" "OutputType" "%s"]'):format(outputType))
     SKIN:Bang(('[!SetOption "Command" "State" "%s"]'):format(state))

--- a/src/settings/pages/shortcuts.moon
+++ b/src/settings/pages/shortcuts.moon
@@ -21,7 +21,7 @@ class Shortcuts extends Page
 				tooltip: LOCALIZATION\get('setting_shortcuts_open_folder_description', 'Shortcuts and their banners should be placed in this folder. The banners should be named after their corresponding shortcut.')
 				label: LOCALIZATION\get('button_label_open', 'Open')
 				perform:() =>
-					SKIN\Bang(('[%s]')\format(io.joinPaths(STATE.PATHS.RESOURCES, 'Shortcuts\\')))
+					SKIN\Bang(('["%s"]')\format(io.joinPaths(STATE.PATHS.RESOURCES, 'Shortcuts\\')))
 			})
 			Settings.Action({
 				title: LOCALIZATION\get('button_label_starting_bangs', 'Starting bangs')

--- a/src/shared/utility.moon
+++ b/src/shared/utility.moon
@@ -161,7 +161,7 @@ return {
 		assert(type(parameter) == 'string', 'shared.utility.runCommand')
 		assert(type(output) == 'string', 'shared.utility.runCommand')
 		assert(type(callback) == 'string', 'shared.utility.runCommand')
-		SKIN\Bang(('[!SetOption "Command" "Parameter" "%s"]')\format(parameter))
+		SKIN\Bang('[!SetOption "Command" "Parameter" """' .. parameter .. '"""]')
 		SKIN\Bang(('[!SetOption "Command" "OutputFile" "%s"]')\format(output))
 		SKIN\Bang(('[!SetOption "Command" "OutputType" "%s"]')\format(outputType))
 		SKIN\Bang(('[!SetOption "Command" "State" "%s"]')\format(state))


### PR DESCRIPTION
Hello! This is similar as #133. When there are spaces on paths edit bangs and open shortcuts folder (on settings.ini) won't open. This solve it.

Regards.